### PR TITLE
Resolve dependency issues in step 2

### DIFF
--- a/libdrc-vnc/drcvncclient/src/Makefile
+++ b/libdrc-vnc/drcvncclient/src/Makefile
@@ -256,7 +256,7 @@ top_build_prefix = ../
 top_builddir = ..
 top_srcdir = ..
 x264_CFLAGS = -I/usr/local/include
-x264_LIBS = -L/usr/local/lib -lx264 -L/usr/local/lib -lswscale
+x264_LIBS = -L/usr/local/lib -lx264 -L/usr/local/lib -lswscale -ldl -lpthread
 AM_CXXFLAGS = $(sdl2_CFLAGS) $(libvncclient_CFLAGS) $(libdrc_CFLAGS) \
               $(x264_CFLAGS)
 


### PR DESCRIPTION
Fixed the missing dependencies problem with the x264 libraries which occurred at link time with newer versions of Ubuntu. It should be noted that you will still need to use kernel 5.11 or 5.12 on newer ubuntu releases due to the patches being incompatible with the 5.13+ kernel releases.